### PR TITLE
Add device show page design with manual page

### DIFF
--- a/app/assets/stylesheets/config/_fonts.scss
+++ b/app/assets/stylesheets/config/_fonts.scss
@@ -1,5 +1,6 @@
 // Import Google fonts
 @import url('https://fonts.googleapis.com/css?family=Nunito:400,700|Work+Sans:400,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700;800&display=swap');
 
 // Define fonts for body and headers
 $body-font: "Work Sans", "Helvetica", "sans-serif";

--- a/app/assets/stylesheets/pages/_device.scss
+++ b/app/assets/stylesheets/pages/_device.scss
@@ -1,0 +1,446 @@
+/* Device show page */
+
+body:has(.device-page) {
+  background: #F6F8F8;
+}
+
+
+.device-page {
+  width: 100%;
+  max-width: 430px;
+  margin: 0 auto;
+  background: #F6F8F8;
+  display: flex;
+  flex-direction: column;
+  font-family: "Space Grotesk", sans-serif;
+}
+
+/* ── Header ──────────────────────────────────────────────────── */
+
+.device-header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 20px 60px 16px;
+  background: #F6F8F8;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.device-back-link {
+  position: absolute;
+  left: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #1a1a2e;
+  font-size: 18px;
+  text-decoration: none;
+
+  &:hover {
+    color: #4ECDC4;
+  }
+}
+
+.device-header-info {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.device-identified-label {
+  font-size: 10px;
+  font-weight: 700;
+  color: #4ECDC4;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  margin-bottom: 3px;
+}
+
+.device-title {
+  font-size: 18px;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin: 0;
+  line-height: 1.2;
+}
+
+/* ── Hero image ──────────────────────────────────────────────── */
+
+.device-hero {
+  position: relative;
+  width: 100%;
+  padding: 0 16px;
+  margin-top: 36px;
+  margin-bottom: 28px;
+
+  /* Dark gradient overlay at the bottom of the hero image */
+  &::after {
+    content: "";
+    position: absolute;
+    bottom: 0;
+    left: 16px;
+    right: 16px;
+    height: 60%;
+    border-radius: 0 0 20px 20px;
+    background: linear-gradient(to top, rgba(0, 0, 0, 0.55) 0%, transparent 100%);
+    pointer-events: none;
+  }
+}
+
+.device-hero-img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+  display: block;
+  border-radius: 20px;
+}
+
+/* Device name overlaid on hero image */
+.device-hero-name {
+  position: absolute;
+  bottom: 16px;
+  left: 30px;
+  right: 30px;
+  color: white;
+  font-size: 26px;
+  font-weight: 800;
+  margin: 0;
+  line-height: 1.2;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.6);
+  z-index: 1;
+}
+
+.device-verified-badge {
+  position: absolute;
+  bottom: 58px;
+  left: 30px;
+  z-index: 1;
+  background: #4ECDC4;
+  color: white;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  padding: 5px 12px;
+  border-radius: 20px;
+
+  i {
+    margin-right: 4px;
+  }
+}
+
+/* ── Action buttons ──────────────────────────────────────────── */
+
+.device-actions {
+  display: flex;
+  gap: 12px;
+  padding: 0 16px 32px;
+}
+
+/* Watch Video Guide — teal filled card */
+.device-btn-video {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 18px 16px;
+  min-height: 130px;
+  background: linear-gradient(145deg, #4ECDC4, #38bdb5);
+  color: white;
+  border: none;
+  border-radius: 20px;
+  font-size: 15px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: opacity 0.2s;
+  line-height: 1.3;
+
+  .device-btn-icon {
+    width: 44px;
+    height: 44px;
+    background: rgba(0, 0, 0, 0.18);
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    i {
+      font-size: 18px;
+      color: white;
+    }
+  }
+
+  .device-btn-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  span {
+    display: block;
+  }
+
+  &:hover {
+    opacity: 0.9;
+    color: white;
+    text-decoration: none;
+  }
+}
+
+/* Read Manual — white card */
+.device-btn-manual {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 18px 16px;
+  min-height: 130px;
+  background: white;
+  color: #1a1a2e;
+  border: none;
+  border-radius: 20px;
+  font-size: 15px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: box-shadow 0.2s;
+  line-height: 1.3;
+
+  .device-btn-icon {
+    width: 44px;
+    height: 44px;
+    background: #e8faf9;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    i {
+      font-size: 18px;
+      color: #4ECDC4;
+    }
+  }
+
+  .device-btn-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  span {
+    display: block;
+  }
+
+  &:hover {
+    box-shadow: 0 4px 16px rgba(78, 205, 196, 0.15);
+    color: #1a1a2e;
+    text-decoration: none;
+  }
+}
+
+/* Pulsing dot animation for "Available" status */
+@keyframes pulse-dot {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50%       { opacity: 0.4; transform: scale(0.7); }
+}
+
+/* Status line below button label */
+.device-btn-status {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+
+  &--available {
+    color: #22c55e;
+  }
+
+  &--unavailable {
+    color: rgba(255, 255, 255, 0.55);
+    font-style: italic;
+  }
+}
+
+/* The pulsing dot — live green */
+.device-btn-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: #22c55e;
+  display: inline-block;
+  flex-shrink: 0;
+  animation: pulse-dot 1.6s ease-in-out infinite;
+}
+
+/* Video button when no video — muted appearance */
+.device-btn-video--unavailable {
+  background: #a8deda;
+  cursor: default;
+  pointer-events: none;
+}
+
+/* ── Related devices carousel ────────────────────────────────── */
+
+.device-related-section {
+  padding: 0 16px 28px;
+}
+
+.device-related-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: #4ECDC4;
+  letter-spacing: 0.6px;
+  margin-bottom: 14px;
+
+  i {
+    margin-right: 5px;
+  }
+}
+
+/* Carousel outer — clips the moving inner track */
+.device-related-scroll {
+  overflow: hidden;
+  padding-bottom: 4px;
+}
+
+/* Keyframe: slide left by exactly 50% (one full set of cards) */
+@keyframes carousel-ticker {
+  0%   { transform: translateX(0); }
+  100% { transform: translateX(-50%); }
+}
+
+/* Inner track — flex row, CSS animated, cards duplicated by JS */
+.device-carousel-inner {
+  display: flex;
+  gap: 12px;
+  width: max-content;
+  animation: carousel-ticker 20s linear infinite;
+
+  &.paused {
+    animation-play-state: paused;
+  }
+
+  /* button_to wraps content in <form> — hide it from flex layout */
+  form {
+    display: contents;
+  }
+}
+
+/* Each device card */
+.device-related-card {
+  flex-shrink: 0;
+  width: 115px;
+  border: 1.5px solid #e4e4e4;
+  border-radius: 16px;
+  overflow: hidden;
+  background: white;
+  text-align: center;
+  cursor: pointer;
+  padding: 0;
+  position: relative;
+  transition: border-color 0.2s, box-shadow 0.2s;
+
+  &:hover {
+    border-color: #4ECDC4;
+    box-shadow: 0 2px 10px rgba(78, 205, 196, 0.15);
+  }
+
+  /* Active / selected state */
+  &--active {
+    border-color: #4ECDC4;
+    box-shadow: 0 2px 10px rgba(78, 205, 196, 0.15);
+  }
+}
+
+.device-related-img {
+  width: 100%;
+  height: 90px;
+  object-fit: cover;
+  display: block;
+}
+
+/* Teal checkmark on the active card */
+.device-related-check {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 22px;
+  height: 22px;
+  background: #4ECDC4;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  i {
+    font-size: 10px;
+    color: white;
+  }
+}
+
+.device-related-name {
+  font-size: 11px;
+  font-weight: 600;
+  color: #1a1a2e;
+  padding: 8px 6px;
+  margin: 0;
+  line-height: 1.3;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── See More button ─────────────────────────────────────────── */
+
+.device-see-more-wrapper {
+  padding: 4px 16px 20px;
+}
+
+.device-see-more-btn {
+  width: 100%;
+  padding: 16px;
+  background: linear-gradient(135deg, #4ECDC4, #44E0B8);
+  color: white;
+  border: none;
+  border-radius: 50px;
+  font-size: 15px;
+  font-weight: 700;
+  font-family: "Space Grotesk", sans-serif;
+  letter-spacing: 0.2px;
+  transition: opacity 0.2s;
+
+  &:hover {
+    opacity: 0.9;
+    color: white;
+  }
+}
+
+/* ── Manual page (manual.html.erb) ───────────────────────────── */
+
+.device-manual {
+  padding: 8px 20px 20px;
+  flex: 1;
+
+  h1, h2, h3 {
+    font-size: 16px;
+    font-weight: 700;
+    color: #1a1a2e;
+    margin-bottom: 8px;
+  }
+
+  p {
+    font-size: 14px;
+    color: #444;
+    line-height: 1.6;
+  }
+
+  ol, ul {
+    padding-left: 20px;
+    font-size: 14px;
+    color: #444;
+    line-height: 1.8;
+  }
+}

--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -3,3 +3,4 @@
 @import "explore";
 @import "auth";
 @import "profile";
+@import "device";

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -6,6 +6,10 @@ class DevicesController < ApplicationController
     @device.increment!(:views)
   end
 
+  def manual
+    @device = Device.find(params[:id])
+  end
+
   # rubocop:disable Metrics/MethodLength, Metrics/PerceivedComplexity, Metrics/AbcSize
   def create
     uploaded_image = params[:device_image]

--- a/app/views/devices/manual.html.erb
+++ b/app/views/devices/manual.html.erb
@@ -1,0 +1,27 @@
+<%# Text Manual page — device photo + full instructions %>
+<% content_for :title, "#{@device.name} Manual" %>
+
+<div class="device-page">
+
+  <%# Header: back to device show %>
+  <div class="device-header">
+    <%= link_to device_path(@device), class: "device-back-link" do %>
+      <i class="fa-solid fa-arrow-left"></i>
+    <% end %>
+    <div class="device-header-info">
+      <span class="device-identified-label">TEXT MANUAL</span>
+      <h1 class="device-title"><%= @device.name %></h1>
+    </div>
+  </div>
+
+  <%# Device photo %>
+  <div class="device-hero">
+    <%= device_image_tag(@device, class: "device-hero-img", alt: @device.name) %>
+  </div>
+
+  <%# Full text instructions %>
+  <div class="device-manual">
+    <%= markdown(@device.text_instructions) %>
+  </div>
+
+</div>

--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -1,29 +1,145 @@
-<div class="mb-3">
-  <%= device_image_tag(@device, class: "rounded shadow-sm w-100", alt: @device.name, style: "max-height: 200px; object-fit: cover;") %>
-</div>
+<%# Device show page — matches Know-How UI design %>
+<% content_for :title, @device.name %>
 
-<div class="mb-2">
-  <span class="badge bg-secondary"><%= @device.category.category_name %></span>
-  <span class="text-muted ms-2"><%= @device.views %> <%= "view".pluralize(@device.views) %></span>
-</div>
+<div class="device-page">
 
-<h1 class="fw-bold"><%= @device.name %></h1>
-
-<div class="mt-4">
-  <%= markdown(@device.text_instructions) %>
-</div>
-
-<% if @device.related_devices.present? %>
-  <div class="mt-5">
-    <h5 class="fw-semibold">Related Devices</h5>
-    <ul class="list-unstyled mt-2">
-      <% @device.related_devices.each do |related| %>
-        <li>
-          <%= button_to related, devices_path, params: { device: { name: related } },
-                method: :post,
-                class: "btn btn-link p-0 text-decoration-none text-muted" %>
-        </li>
-      <% end %>
-    </ul>
+  <%# Header: back arrow + identified label + device name %>
+  <div class="device-header">
+    <%= link_to :back, class: "device-back-link" do %>
+      <i class="fa-solid fa-arrow-left"></i>
+    <% end %>
+    <div class="device-header-info">
+      <span class="device-identified-label">IDENTIFIED DEVICE</span>
+      <h1 class="device-title"><%= @device.name %></h1>
+    </div>
   </div>
-<% end %>
+
+  <%# Hero image with verified badge %>
+  <div class="device-hero">
+    <%= device_image_tag(@device, class: "device-hero-img", alt: @device.name) %>
+    <span class="device-verified-badge">
+      <i class="fa-solid fa-circle-check"></i> VERIFIED MODEL
+    </span>
+    <h2 class="device-hero-name"><%= @device.name %></h2>
+  </div>
+
+  <%# Action buttons — both always shown; video button indicates availability %>
+  <div class="device-actions">
+
+    <%# Watch Video Guide — dimmed with notice if no video exists %>
+    <%= link_to (@device.video.present? ? "#" : nil), class: "btn device-btn-video #{'device-btn-video--unavailable' unless @device.video.present?}" do %>
+      <div class="device-btn-icon">
+        <i class="fa-solid fa-play"></i>
+      </div>
+      <div class="device-btn-label">
+        <span>Watch Video Guide</span>
+        <% if @device.video.present? %>
+          <span class="device-btn-status device-btn-status--available">
+            <span class="device-btn-dot"></span> Available
+          </span>
+        <% else %>
+          <span class="device-btn-status device-btn-status--unavailable">
+            No video available
+          </span>
+        <% end %>
+      </div>
+    <% end %>
+
+    <%# Read Manual — always available %>
+    <%= link_to manual_device_path(@device), class: "btn device-btn-manual" do %>
+      <div class="device-btn-icon">
+        <i class="fa-solid fa-book-open"></i>
+      </div>
+      <div class="device-btn-label">
+        <span>Read Manual</span>
+        <span class="device-btn-status device-btn-status--available">
+          <span class="device-btn-dot"></span> Available
+        </span>
+      </div>
+    <% end %>
+
+  </div>
+
+  <%# Related devices — horizontal scroll with images %>
+  <% if @device.related_devices.present? %>
+    <div class="device-related-section">
+      <p class="device-related-label">
+        <i class="fa-solid fa-rotate-left"></i>
+        SPECIFY MODEL/SELECT A DIFFERENT MODEL
+      </p>
+
+      <div class="device-related-scroll">
+        <div class="device-carousel-inner" id="carouselInner">
+
+          <%# Current device card — highlighted as selected %>
+          <div class="device-related-card device-related-card--active">
+            <%= device_image_tag(@device, class: "device-related-img", alt: @device.name) %>
+            <span class="device-related-check"><i class="fa-solid fa-check"></i></span>
+            <p class="device-related-name"><%= @device.name %></p>
+          </div>
+
+          <%# Other possible device models — clicking searches for that device %>
+          <% @device.related_devices.each do |related_name| %>
+            <% related = Device.find_by(name: related_name) %>
+            <%= button_to devices_path, method: :post,
+                          params: { device: { name: related_name } },
+                          class: "device-related-card" do %>
+              <% if related %>
+                <%= device_image_tag(related, class: "device-related-img", alt: related_name) %>
+              <% else %>
+                <%= category_image_tag(@device.category, class: "device-related-img", alt: related_name) %>
+              <% end %>
+              <p class="device-related-name"><%= related_name %></p>
+            <% end %>
+          <% end %>
+
+        </div>
+      </div>
+    </div>
+
+    <%# See More — searches for more devices like this one %>
+    <div class="device-see-more-wrapper">
+      <%= button_to "Click to See More", devices_path, method: :post,
+                    params: { device: { name: @device.name } },
+                    class: "btn device-see-more-btn" %>
+    </div>
+  <% end %>
+
+</div>
+
+<%# CSS ticker carousel — duplicate cards and set animation duration based on card count %>
+<script>
+  // Remove layout's inline padding-bottom so no gap appears below the page content
+  const mainEl = document.querySelector("main");
+  if (mainEl) mainEl.style.paddingBottom = "0";
+
+  const inner = document.getElementById("carouselInner");
+  if (inner) {
+    // Duplicate the inner HTML for a seamless loop
+    inner.innerHTML += inner.innerHTML;
+
+    // Set duration proportional to number of cards so speed stays consistent
+    const cardCount = inner.querySelectorAll(".device-related-card").length;
+    inner.style.animationDuration = (cardCount * 2.5) + "s";
+
+    // On card click: pause animation and show checkmark
+    inner.addEventListener("click", function (e) {
+      const card = e.target.closest(".device-related-card");
+      if (!card) return;
+
+      inner.classList.add("paused");
+
+      inner.querySelectorAll(".device-related-card").forEach(function (c) {
+        c.classList.remove("device-related-card--active");
+        const existing = c.querySelector(".device-related-check");
+        if (existing) existing.remove();
+      });
+
+      card.classList.add("device-related-card--active");
+      const check = document.createElement("span");
+      check.className = "device-related-check";
+      check.innerHTML = '<i class="fa-solid fa-check"></i>';
+      card.appendChild(check);
+    });
+  }
+</script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: "users/registrations" }
   root to: "pages#home"
-  resources :devices, only: [:create, :show]
+  resources :devices, only: [:create, :show] do
+    member do
+      get :manual
+    end
+  end
   get "explore", to: "pages#explore"
   get "explore/category/:id", to: "pages#explore_category", as: :explore_category
   get "profile", to: "users#show", as: :profile


### PR DESCRIPTION
 Summary
- Redesigned device show page to match Figma prototype using Space Grotesk font
- Added hero image with dark gradient overlay, verified badge, and device name
- Added Watch Video Guide and Read Manual action cards with pulsing availability indicators
- Added auto-scrolling CSS carousel for related devices (click to pause + select)
- Added new Text Manual page showing device photo and markdown instructions
- Added manual route and controller action

