### PR TITLE
Fix back button on device show page to always go to home

### DIFF
--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -5,7 +5,7 @@
 
   <%# Header: back arrow + identified label + device name %>
   <div class="device-header">
-    <%= link_to :back, class: "device-back-link" do %>
+    <%= link_to root_path, class: "device-back-link" do %>
       <i class="fa-solid fa-arrow-left"></i>
     <% end %>
     <div class="device-header-info">


### PR DESCRIPTION
Replaced `link_to :back` with `link_to root_path` on the device show page back arrow
 