### PR TITLE
Add related devices page with search and list layout

### DIFF
--- a/app/assets/stylesheets/pages/_device.scss
+++ b/app/assets/stylesheets/pages/_device.scss
@@ -449,6 +449,152 @@ main:has(.device-page) {
   }
 }
 
+/* ── Related devices page (related.html.erb) ─────────────────── */
+
+/* Search bar wrapper */
+.device-match-search-wrapper {
+  padding: 20px 16px 12px;
+}
+
+.device-match-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+
+.device-match-search-icon {
+  position: absolute;
+  left: 16px;
+  color: #b0b0b0;
+  font-size: 14px;
+  pointer-events: none;
+}
+
+.device-match-search-input {
+  width: 100%;
+  padding: 14px 16px 14px 42px;
+  border: 1.5px solid #e4e4e4;
+  border-radius: 14px;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 14px;
+  color: #1a1a2e;
+  background: white;
+  outline: none;
+  transition: border-color 0.2s;
+
+  &::placeholder {
+    color: #b0b0b0;
+  }
+
+  &:focus {
+    border-color: #4ECDC4;
+  }
+}
+
+/* Section label */
+.device-match-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: #4ECDC4;
+  letter-spacing: 0.6px;
+  padding: 0 16px 12px;
+  margin: 0;
+
+  i {
+    margin-right: 5px;
+  }
+}
+
+/* Device list container */
+.device-match-list {
+  padding: 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* Each row: thumbnail + name + radio */
+.device-match-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  background: white;
+  border: 1.5px solid #e4e4e4;
+  border-radius: 16px;
+  cursor: pointer;
+  text-decoration: none;
+  color: #1a1a2e;
+  transition: border-color 0.2s, box-shadow 0.2s;
+  width: 100%;
+  text-align: left;
+
+  /* button_to wraps in a form — collapse it so the row is the only flex child */
+  form {
+    display: contents;
+  }
+
+  &:hover {
+    border-color: #4ECDC4;
+    text-decoration: none;
+    color: #1a1a2e;
+  }
+
+  /* Selected state — teal border */
+  &--selected {
+    border-color: #4ECDC4;
+    box-shadow: 0 2px 10px rgba(78, 205, 196, 0.15);
+  }
+}
+
+/* Device thumbnail */
+.device-match-img {
+  width: 60px;
+  height: 60px;
+  object-fit: cover;
+  border-radius: 12px;
+  flex-shrink: 0;
+}
+
+/* Device name — takes remaining space */
+.device-match-name {
+  flex: 1;
+  font-size: 14px;
+  font-weight: 600;
+  color: #1a1a2e;
+  line-height: 1.3;
+}
+
+/* Radio circle on the right */
+.device-match-radio {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid #d0d0d0;
+  flex-shrink: 0;
+  position: relative;
+  transition: border-color 0.2s;
+
+  /* Filled teal radio for the selected row */
+  &--selected {
+    border-color: #4ECDC4;
+    background: #4ECDC4;
+
+    /* Inner white dot */
+    &::after {
+      content: "";
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      width: 7px;
+      height: 7px;
+      border-radius: 50%;
+      background: white;
+    }
+  }
+}
+
 /* ── Manual page (manual.html.erb) ───────────────────────────── */
 
 .device-manual {

--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -10,6 +10,10 @@ class DevicesController < ApplicationController
     @device = Device.find(params[:id])
   end
 
+  def related
+    @device = Device.find(params[:id])
+  end
+
   def create
     uploaded_image = params[:device_image].presence || params[:device_camera_image].presence
     input_name = params.dig(:device, :name)

--- a/app/views/devices/related.html.erb
+++ b/app/views/devices/related.html.erb
@@ -1,0 +1,70 @@
+<%# Related devices page — list of alternative matches for a device %>
+<% content_for :title, "Identify Device" %>
+
+<div class="device-page device-related-page">
+
+  <%# Header: back arrow + "Identify Device" title %>
+  <div class="device-header">
+    <%= link_to device_path(@device), class: "device-back-link" do %>
+      <i class="fa-solid fa-arrow-left"></i>
+    <% end %>
+    <div class="device-header-info">
+      <h1 class="device-title">Identify Device</h1>
+    </div>
+  </div>
+
+  <%# Search input — submits to devices#create exactly like the home page search %>
+  <%= form_with url: devices_path, method: :post, class: "device-match-search-wrapper" do |f| %>
+    <div class="device-match-search">
+      <i class="fa-solid fa-magnifying-glass device-match-search-icon"></i>
+      <%= f.text_field :name,
+            name: "device[name]",
+            placeholder: "Input exact model name...",
+            class: "device-match-search-input",
+            autocomplete: "off" %>
+    </div>
+  <% end %>
+
+  <%# Section label %>
+  <p class="device-match-label">
+    <i class="fa-solid fa-layer-group"></i> ALTERNATIVE MATCHES
+  </p>
+
+  <%# Device list %>
+  <div class="device-match-list" id="relatedList">
+
+    <%# Current device — shown as selected %>
+    <div class="device-match-row device-match-row--selected">
+      <%= device_image_tag(@device, class: "device-match-img", alt: @device.name) %>
+      <span class="device-match-name"><%= @device.name %></span>
+      <span class="device-match-radio device-match-radio--selected"></span>
+    </div>
+
+    <%# Related device models from the AI response %>
+    <% @device.related_devices.each do |related_name| %>
+      <% related = Device.find_by(name: related_name) %>
+
+      <% if related %>
+        <%# Device already exists — link directly to its show page %>
+        <%= link_to device_path(related), class: "device-match-row" do %>
+          <%= device_image_tag(related, class: "device-match-img", alt: related_name) %>
+          <span class="device-match-name"><%= related_name %></span>
+          <span class="device-match-radio"></span>
+        <% end %>
+      <% else %>
+        <%# Device doesn't exist yet — POST to create it via the AI %>
+        <%= button_to devices_path, method: :post,
+              params: { device: { name: related_name } },
+              class: "device-match-row" do %>
+          <%= category_image_tag(@device.category, class: "device-match-img", alt: related_name) %>
+          <span class="device-match-name"><%= related_name %></span>
+          <span class="device-match-radio"></span>
+        <% end %>
+      <% end %>
+
+    <% end %>
+
+  </div>
+
+</div>
+

--- a/app/views/devices/show.html.erb
+++ b/app/views/devices/show.html.erb
@@ -105,11 +105,9 @@
       </div>
     </div>
 
-    <%# See More — searches for more devices like this one %>
+    <%# See More — opens the full related devices list page %>
     <div class="device-see-more-wrapper">
-      <%= button_to "Click to See More", devices_path, method: :post,
-                    params: { device: { name: @device.name } },
-                    class: "btn device-see-more-btn" %>
+      <%= link_to "Click to See More", related_device_path(@device), class: "btn device-see-more-btn" %>
     </div>
   <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   resources :devices, only: [:create, :show, :update] do
     member do
       get :manual
+      get :related
     end
     resources :videos, only: [:show]
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,7 +62,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_13_120000) do
   create_table "videos", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.bigint "device_id", null: false
-    t.string "source"
     t.string "summary", null: false
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false


### PR DESCRIPTION
Adds a dedicated related devices page showing all alternative model matches as a scrollable list.
Each row has a thumbnail, device name, and radio button — the current device is pre-selected. 
A search field at the top submits to the same AI identification flow as the home page.
The "See More" button on the device show page now links to this page.