### PR TITLE
Add My Uploads partial to profile page with view count tracking

### DIFF
--- a/app/assets/stylesheets/pages/_profile.scss
+++ b/app/assets/stylesheets/pages/_profile.scss
@@ -193,6 +193,96 @@ body:has(.profile-page) {
   }
 }
 
+/* Upload cards list */
+.profile-uploads-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+/* Each upload row */
+.profile-upload-card {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 12px;
+  border: 1px solid #f0f0f0;
+  border-radius: 14px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+  text-decoration: none;
+  color: inherit;
+  transition: box-shadow 0.2s;
+
+  &:hover {
+    text-decoration: none;
+    color: inherit;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.09);
+  }
+}
+
+/* Square thumbnail */
+.profile-upload-thumb {
+  width: 72px;
+  height: 72px;
+  border-radius: 12px;
+  overflow: hidden;
+  flex-shrink: 0;
+  background: #eee;
+}
+
+.profile-upload-thumb-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* Text info */
+.profile-upload-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.profile-upload-title {
+  font-size: 14px;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin: 0 0 4px;
+  line-height: 1.3;
+
+  /* Clamp to 2 lines */
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.profile-upload-date {
+  font-size: 12px;
+  color: #888;
+  margin: 0 0 6px;
+}
+
+.profile-upload-stats {
+  display: flex;
+  gap: 12px;
+  font-size: 12px;
+  color: #888;
+  font-weight: 600;
+
+  i {
+    margin-right: 4px;
+  }
+}
+
+.profile-uploads-empty {
+  color: #888;
+  font-size: 14px;
+  text-align: center;
+  padding: 20px 0;
+  margin: 0;
+}
+
 /* Edit profile — avatar upload */
 .edit-avatar-section {
   text-align: center;

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -29,6 +29,7 @@ class VideosController < ApplicationController
   def show
     @device = Device.find(params[:device_id])
     @video = @device.video
+    @video.increment!(:views)
   end
 
   private

--- a/app/views/users/_my_uploads.html.erb
+++ b/app/views/users/_my_uploads.html.erb
@@ -1,0 +1,35 @@
+<%# My Uploads partial — shows the current user's uploaded videos %>
+<div class="profile-uploads-section">
+
+  <div class="profile-uploads-header">
+    <h3 class="profile-uploads-title">My Uploads</h3>
+    <%= link_to "See all", "#", class: "profile-see-all" %>
+  </div>
+
+  <% if user.videos.any? %>
+    <div class="profile-uploads-list">
+      <% user.videos.order(created_at: :desc).each do |video| %>
+        <%= link_to device_video_path(video.device, video), class: "profile-upload-card" do %>
+
+          <%# Thumbnail — use the device's first image %>
+          <div class="profile-upload-thumb">
+            <%= device_image_tag(video.device, class: "profile-upload-thumb-img", alt: video.device.name) %>
+          </div>
+
+          <%# Info: title, upload date, stats %>
+          <div class="profile-upload-info">
+            <p class="profile-upload-title"><%= video.summary %></p>
+            <p class="profile-upload-date">Uploaded <%= time_ago_in_words(video.created_at) %> ago</p>
+            <div class="profile-upload-stats">
+              <span><i class="fa-regular fa-eye"></i> <%= video.views >= 1000 ? "#{(video.views / 1000.0).round(1)}K" : video.views %></span>
+            </div>
+          </div>
+
+        <% end %>
+      <% end %>
+    </div>
+  <% else %>
+    <p class="profile-uploads-empty">No uploads yet.</p>
+  <% end %>
+
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -48,20 +48,8 @@
     <i class="fa-solid fa-chevron-right"></i>
   <% end %>
 
-  <%# My Uploads section — placeholder until video upload feature is built %>
-  <div class="profile-uploads-section">
-    <div class="profile-uploads-header">
-      <h3 class="profile-uploads-title">My Uploads</h3>
-      <%# TODO: Link to full uploads list when built %>
-      <%= link_to "See all", "#", class: "profile-see-all" %>
-    </div>
-    <% if @user.videos.any? %>
-      <%# TODO: Render video cards when video display feature is built %>
-      <p class="text-muted">Video cards will appear here.</p>
-    <% else %>
-      <p class="text-muted">No uploads yet.</p>
-    <% end %>
-  </div>
+  <%# My Uploads section %>
+  <%= render "my_uploads", user: @user %>
 
   <%# Sign Out — pinned to bottom %>
   <div class="profile-signout-wrapper">


### PR DESCRIPTION
Adds a My Uploads section to the profile page as a reusable partial. Each card shows the device thumbnail, video title, upload date, and live view count. Also fixes video view counting 
—> views now increment when a video's show page is visited.