### PR TITLE
Redesign video show page with bookmark, share, uploader card, and des…

### DIFF
--- a/app/assets/stylesheets/pages/_index.scss
+++ b/app/assets/stylesheets/pages/_index.scss
@@ -4,3 +4,4 @@
 @import "auth";
 @import "profile";
 @import "device";
+@import "video";

--- a/app/assets/stylesheets/pages/_video.scss
+++ b/app/assets/stylesheets/pages/_video.scss
@@ -1,0 +1,263 @@
+/* Video show page */
+
+body:has(.video-page) {
+  background: #f4f4f4;
+}
+
+main:has(.video-page) {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+.video-page {
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+  background: white;
+  min-height: calc(100vh - 60px);
+  display: flex;
+  flex-direction: column;
+  font-family: "Space Grotesk", sans-serif;
+  padding-bottom: 80px;
+}
+
+/* ── Header ──────────────────────────────────────────────────── */
+
+.video-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 20px 14px;
+}
+
+.video-back-link {
+  color: #1a1a2e;
+  font-size: 20px;
+  text-decoration: none;
+  width: 32px;
+
+  &:hover { color: #4ECDC4; }
+}
+
+.video-header-title {
+  font-size: 17px;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin: 0;
+}
+
+.video-share-btn {
+  width: 32px;
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 18px;
+  color: #1a1a2e;
+  cursor: pointer;
+  text-align: right;
+
+  &:hover { color: #4ECDC4; }
+}
+
+/* ── Video player ────────────────────────────────────────────── */
+
+.video-player-wrapper {
+  width: 100%;
+  background: #000;
+}
+
+.video-player {
+  width: 100%;
+  display: block;
+  max-height: 260px;
+  object-fit: cover;
+}
+
+/* ── Info below player ───────────────────────────────────────── */
+
+.video-info {
+  padding: 16px 20px 12px;
+}
+
+/* Title row — title + bookmark side by side */
+.video-title-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  margin-bottom: 6px;
+}
+
+.video-title {
+  flex: 1;
+  font-size: 20px;
+  font-weight: 800;
+  color: #1a1a2e;
+  margin: 0;
+  line-height: 1.3;
+}
+
+/* Bookmark button — teal rounded square */
+.video-bookmark-btn {
+  flex-shrink: 0;
+  width: 42px;
+  height: 42px;
+  background: #e8faf9;
+  border: none;
+  border-radius: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background 0.2s;
+  padding: 0;
+
+  i {
+    font-size: 17px;
+    color: #4ECDC4;
+  }
+
+  &:hover { background: #d0f5f2; }
+
+  /* Saved state — filled icon, slightly deeper background */
+  &--saved {
+    background: #4ECDC4;
+
+    i { color: white; }
+    &:hover { background: #3dbdb5; }
+  }
+}
+
+.video-meta {
+  font-size: 13px;
+  color: #888;
+  margin: 0;
+}
+
+/* ── Uploader card ───────────────────────────────────────────── */
+
+.video-uploader-card {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 4px 16px 16px;
+  padding: 14px 16px;
+  background: #f8f9fa;
+  border-radius: 16px;
+}
+
+.video-uploader-avatar {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #e6faf7, #d4f5ef);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.video-uploader-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.video-uploader-placeholder {
+  font-size: 20px;
+  color: #4ECDC4;
+}
+
+.video-uploader-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.video-uploader-name {
+  font-size: 14px;
+  font-weight: 700;
+  color: #1a1a2e;
+  margin: 0 0 2px;
+}
+
+.video-uploader-role {
+  font-size: 10px;
+  font-weight: 700;
+  color: #888;
+  letter-spacing: 0.6px;
+  margin: 0;
+}
+
+.video-view-uploads-btn {
+  padding: 10px 16px;
+  background: #4ECDC4;
+  color: white;
+  border-radius: 50px;
+  font-size: 13px;
+  font-weight: 700;
+  text-decoration: none;
+  white-space: nowrap;
+  transition: opacity 0.2s;
+  flex-shrink: 0;
+
+  &:hover { opacity: 0.9; color: white; text-decoration: none; }
+}
+
+/* ── Brief Description accordion ────────────────────────────── */
+
+.video-description-section {
+  margin: 0 16px;
+  border: 1px solid #e9ecef;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.video-description-toggle {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px;
+  background: white;
+  border: none;
+  cursor: pointer;
+  font-family: "Space Grotesk", sans-serif;
+  font-size: 15px;
+  font-weight: 600;
+  color: #1a1a2e;
+
+  &:hover { background: #fafafa; }
+}
+
+.video-description-toggle-left {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+
+  i { color: #4ECDC4; font-size: 16px; }
+}
+
+.video-description-chevron {
+  color: #888;
+  font-size: 13px;
+  transition: transform 0.25s ease;
+}
+
+/* Hidden by default — toggled open by JS */
+.video-description-body {
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s ease;
+
+  &--open {
+    max-height: 400px;
+  }
+}
+
+.video-description-text {
+  padding: 0 16px 16px;
+  font-size: 14px;
+  color: #555;
+  line-height: 1.6;
+  margin: 0;
+}

--- a/app/controllers/videos_controller.rb
+++ b/app/controllers/videos_controller.rb
@@ -30,6 +30,7 @@ class VideosController < ApplicationController
     @device = Device.find(params[:device_id])
     @video = @device.video
     @video.increment!(:views)
+    @bookmark = user_signed_in? ? current_user.bookmarks.find_by(device: @device) : nil
   end
 
   private

--- a/app/views/videos/show.html.erb
+++ b/app/views/videos/show.html.erb
@@ -1,10 +1,162 @@
-<h1><%= @device.name %> — Video Guide</h1>
+<%# Video show page — matches Know-How UI design %>
+<% content_for :title, "Video Instruction" %>
 
-<p><%= @video.summary %></p>
+<div class="video-page">
 
-<video controls width="100%">
-  <source src="<%= @video.video_link %>" type="video/mp4">
-  Your browser does not support the video tag.
-</video>
+  <%# Header: back arrow + title + share icon %>
+  <div class="video-header">
+    <%= link_to device_path(@device), class: "video-back-link" do %>
+      <i class="fa-solid fa-arrow-left"></i>
+    <% end %>
+    <h1 class="video-header-title">Video Instruction</h1>
+    <%# Share icon — uses Web Share API if available, otherwise copies URL %>
+    <button class="video-share-btn" id="shareBtn" aria-label="Share">
+      <i class="fa-solid fa-share-nodes"></i>
+    </button>
+  </div>
 
-<%= link_to "Back to Device", device_path(@device) %>
+  <%# Video player — native HTML5 player with the Cloudinary URL %>
+  <div class="video-player-wrapper">
+    <video
+      class="video-player"
+      controls
+      playsinline
+      preload="metadata"
+      poster="<%= @device.images.first.presence || '' %>"
+    >
+      <source src="<%= @video.video_link %>" type="video/mp4">
+      Your browser does not support the video tag.
+    </video>
+  </div>
+
+  <%# Title + meta + bookmark below player %>
+  <div class="video-info">
+    <div class="video-title-row">
+      <h2 class="video-title"><%= @video.summary %></h2>
+
+      <%# Bookmark button — saves/unsaves the device %>
+      <% if @bookmark %>
+        <%= button_to bookmark_path(@bookmark), method: :delete,
+              class: "video-bookmark-btn video-bookmark-btn--saved",
+              title: "Remove bookmark",
+              form: { data: { turbo: false } } do %>
+          <i class="fa-solid fa-bookmark"></i>
+        <% end %>
+      <% else %>
+        <%= button_to bookmarks_path, method: :post,
+              params: { device_id: @device.id },
+              class: "video-bookmark-btn",
+              title: "Save device",
+              form: { data: { turbo: false } } do %>
+          <i class="fa-regular fa-bookmark"></i>
+        <% end %>
+      <% end %>
+    </div>
+
+    <p class="video-meta">
+      <%= @video.views >= 1000 ? "#{(@video.views / 1000.0).round(1)}K" : @video.views %> views
+      &bull;
+      <%= time_ago_in_words(@video.created_at) %> ago
+    </p>
+  </div>
+
+  <%# Uploader card %>
+  <div class="video-uploader-card">
+    <div class="video-uploader-avatar">
+      <% if @video.user.picture.present? %>
+        <%= image_tag @video.user.picture, class: "video-uploader-img", alt: @video.user.full_name %>
+      <% else %>
+        <i class="fa-solid fa-user video-uploader-placeholder"></i>
+      <% end %>
+    </div>
+    <div class="video-uploader-info">
+      <p class="video-uploader-name"><%= @video.user.full_name || @video.user.username %></p>
+      <p class="video-uploader-role">VIDEO CONTRIBUTOR</p>
+    </div>
+    <%= link_to profile_path, class: "video-view-uploads-btn" do %>
+      View Uploads
+    <% end %>
+  </div>
+
+  <%# Brief Description — collapsible accordion %>
+  <div class="video-description-section" id="descSection">
+    <button class="video-description-toggle" id="descToggle" aria-expanded="false">
+      <span class="video-description-toggle-left">
+        <i class="fa-regular fa-file-lines"></i>
+        <span>Brief Description</span>
+      </span>
+      <i class="fa-solid fa-chevron-down video-description-chevron" id="descChevron"></i>
+    </button>
+    <div class="video-description-body" id="descBody">
+      <p class="video-description-text"><%= @video.summary %></p>
+    </div>
+  </div>
+
+</div>
+
+<script>
+  // Remove layout's inline padding-bottom
+  const mainEl = document.querySelector("main");
+  if (mainEl) mainEl.style.paddingBottom = "0";
+
+  // Collapsible description
+  const toggle = document.getElementById("descToggle");
+  const body   = document.getElementById("descBody");
+  const chevron = document.getElementById("descChevron");
+
+  if (toggle && body) {
+    toggle.addEventListener("click", function () {
+      const isOpen = body.classList.toggle("video-description-body--open");
+      chevron.style.transform = isOpen ? "rotate(180deg)" : "rotate(0deg)";
+      toggle.setAttribute("aria-expanded", isOpen);
+    });
+  }
+
+  // Share button — Web Share API with clipboard fallback
+  const shareBtn = document.getElementById("shareBtn");
+
+  function showShareToast() {
+    let toast = document.getElementById("shareToast");
+    if (!toast) {
+      toast = document.createElement("div");
+      toast.id = "shareToast";
+      toast.style.cssText = "position:fixed;bottom:100px;left:50%;transform:translateX(-50%);background:#1a1a2e;color:white;padding:10px 20px;border-radius:50px;font-size:13px;font-weight:600;z-index:9999;font-family:'Space Grotesk',sans-serif;";
+      document.body.appendChild(toast);
+    }
+    toast.textContent = "Link copied!";
+    toast.style.display = "block";
+    setTimeout(function () { toast.style.display = "none"; }, 2500);
+  }
+
+  function copyUrl() {
+    const url = window.location.href;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(url).then(showShareToast).catch(function () {
+        fallbackCopy(url);
+      });
+    } else {
+      fallbackCopy(url);
+    }
+  }
+
+  function fallbackCopy(url) {
+    const el = document.createElement("textarea");
+    el.value = url;
+    el.style.cssText = "position:fixed;top:-9999px;left:-9999px;";
+    document.body.appendChild(el);
+    el.focus();
+    el.select();
+    try { document.execCommand("copy"); showShareToast(); } catch (e) {}
+    document.body.removeChild(el);
+  }
+
+  if (shareBtn) {
+    shareBtn.addEventListener("click", function () {
+      if (navigator.share) {
+        navigator.share({ title: document.title, url: window.location.href }).catch(function () {});
+      } else {
+        copyUrl();
+      }
+    });
+  }
+</script>


### PR DESCRIPTION
Redesigns the video show page to match the prototype. Includes a native HTML5 video player with device image as poster, bookmark button (saves/unsaves the device, toggles filled/outline state), share button using Web Share API with clipboard fallback and "Link copied!" toast, uploader card with avatar and View Uploads link, and a collapsible Brief Description accordion.