### PR TITLE
Change 'Available' text color on Watch Video Guide button

### DIFF
--- a/app/assets/stylesheets/pages/_device.scss
+++ b/app/assets/stylesheets/pages/_device.scss
@@ -332,7 +332,7 @@ main:has(.device-page) {
   line-height: 1;
 
   &--available {
-    color: #22c55e;
+    color: #d00000;
   }
 
   &--unavailable {
@@ -346,7 +346,7 @@ main:has(.device-page) {
   width: 7px;
   height: 7px;
   border-radius: 50%;
-  background: #22c55e;
+  background: #d00000;
   display: inline-block;
   flex-shrink: 0;
   vertical-align: middle;


### PR DESCRIPTION
Updated the "Available" status text color on the Watch Video Guide button 

changed from green (#22c55e) to #d00000 (red).