### PR TITLE
Redesign text manual page with card layout, step timeline, and scroll animation

### DIFF
--- a/app/assets/stylesheets/pages/_device.scss
+++ b/app/assets/stylesheets/pages/_device.scss
@@ -632,29 +632,336 @@ main:has(.device-page) {
   }
 }
 
-/* ── Manual page (manual.html.erb) ───────────────────────────── */
+/* ══════════════════════════════════════════════════════════════
+   Manual page redesign (manual.html.erb)
+   ══════════════════════════════════════════════════════════════ */
 
-.device-manual {
-  padding: 8px 20px 20px;
-  flex: 1;
+/* Override background for the manual page */
+.device-page--manual {
+  background: white;
+}
 
-  h1, h2, h3 {
+body:has(.device-page--manual) {
+  background: white;
+}
+
+/* ── Full-width hero ─────────────────────────────────────────── */
+
+.device-manual-hero {
+  position: relative;
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.device-manual-hero-img {
+  width: 100%;
+  height: 260px;
+  object-fit: cover;
+  display: block;
+  border-radius: 0;
+}
+
+.device-manual-hero-overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(to top, rgba(0,0,0,0.45) 0%, transparent 55%);
+  pointer-events: none;
+}
+
+/* ── Intro card ──────────────────────────────────────────────── */
+
+.device-manual-intro {
+  background: white;
+  padding: 22px 20px 16px;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.device-manual-intro-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 700;
+  color: #4ECDC4;
+  letter-spacing: 0.6px;
+  text-transform: capitalize;
+  margin-bottom: 6px;
+}
+
+.device-manual-intro-title {
+  font-size: 28px;
+  font-weight: 800;
+  color: #1a1a2e;
+  margin: 0 0 8px;
+  line-height: 1.2;
+}
+
+.device-manual-intro-subtitle {
+  font-size: 14px;
+  color: #888;
+  line-height: 1.55;
+  margin: 0;
+}
+
+/* ── Markdown body — numbered step layout ────────────────────── */
+
+.device-manual-body {
+  background: #f7f8fa;
+  padding: 8px 16px 28px;
+
+  /* Each section card — wraps one h2 + its content */
+  .manual-card {
+    background: #fff;
+    border-radius: 16px;
+    padding: 18px 18px 14px;
+    margin-bottom: 14px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.06);
+    position: relative;
+
+    /* Fade-in from below — JS adds .is-visible when card enters viewport */
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.5s cubic-bezier(0.4, 0, 0.2, 1),
+                transform 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+
+    &.is-visible {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  /* Vertical line — only on cards with numbered steps (JS adds .has-timeline).
+     --timeline-top is set by JS to align with the center of the first circle. */
+  .manual-card.has-timeline::before {
+    content: "";
+    position: absolute;
+    left: 35px; /* card padding (18px) + half circle (17px) */
+    top: var(--timeline-top, 52px);
+    bottom: var(--timeline-bottom, 14px);
+    width: 1px;
+    background: linear-gradient(to bottom, #e0e0e0 0%, #e0e0e0 85%, transparent 100%);
+    z-index: 0;
+    pointer-events: none;
+  }
+
+  /* h2 = card title — no numbering, sits above the timeline */
+  h2 {
     font-size: 16px;
     font-weight: 700;
     color: #1a1a2e;
-    margin-bottom: 8px;
+    margin: 0 0 14px;
+    line-height: 1.3;
+    position: relative;
+    z-index: 1;
   }
 
+  /* Bold step headings detected by JS — numbered circle via data-step attr */
+  .manual-step-heading {
+    position: relative;
+    padding-left: 50px;
+    min-height: 34px;
+    margin: 0 0 16px;
+    z-index: 1;
+    display: block;
+
+    &::before {
+      content: attr(data-step);
+      position: absolute;
+      left: 0;
+      top: 0;
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      background: #e4f7f6;
+      color: #4ECDC4;
+      font-size: 13px;
+      font-weight: 700;
+      font-family: "Space Grotesk", sans-serif;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 2;
+    }
+
+  }
+
+  /* h3 = sub-sections inside card — flush, no indent */
+  h3 {
+    font-size: 14px;
+    font-weight: 700;
+    color: #1a1a2e;
+    margin: 14px 0 6px;
+    padding-left: 0;
+    line-height: 1.4;
+  }
+
+  /* All paragraphs — flush, no indent */
   p {
     font-size: 14px;
-    color: #444;
-    line-height: 1.6;
+    color: #555;
+    line-height: 1.7;
+    margin: 0 0 10px;
   }
 
-  ol, ul {
-    padding-left: 20px;
-    font-size: 14px;
-    color: #444;
-    line-height: 1.8;
+  /* Blockquotes — strip all default styling including browser margin-left */
+  blockquote {
+    margin: 0 0 10px 0;
+    padding: 0;
+    border-left: none;
+
+    p { margin-bottom: 6px; }
+  }
+
+  /* Ordered lists */
+  ol {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 12px;
+  }
+
+  /* Step-title lists (JS-marked) — numbered circles */
+  ol.manual-step-list {
+    > li {
+      position: relative;
+      padding-left: 50px;
+      font-size: 14px;
+      color: #555;
+      line-height: 1.65;
+      margin-bottom: 16px;
+      z-index: 1;
+
+      &::before {
+        content: attr(data-step);
+        position: absolute;
+        left: 0;
+        top: 0;
+        width: 34px;
+        height: 34px;
+        border-radius: 50%;
+        background: #e4f7f6;
+        color: #4ECDC4;
+        font-size: 13px;
+        font-weight: 700;
+        font-family: "Space Grotesk", sans-serif;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        z-index: 2;
+      }
+
+      ul, ol {
+        margin-top: 8px;
+        padding-left: 0;
+        li { padding-left: 0; margin-bottom: 6px; }
+      }
+    }
+  }
+
+  /* Plain sub-step lists — no indent, flush */
+  ol:not(.manual-step-list) {
+    padding-left: 0;
+
+    > li {
+      font-size: 14px;
+      color: #555;
+      line-height: 1.65;
+      margin-bottom: 8px;
+    }
+  }
+
+  /* Unordered lists — flush, no indent */
+  ul {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 10px;
+
+    li {
+      font-size: 14px;
+      color: #555;
+      line-height: 1.65;
+      margin-bottom: 8px;
+    }
+  }
+
+  /* strong / bold */
+  strong {
+    color: #1a1a2e;
+    font-weight: 700;
+  }
+
+  /* Inline code */
+  code {
+    background: #f4f6f8;
+    padding: 2px 7px;
+    border-radius: 6px;
+    font-size: 13px;
+    color: #1a1a2e;
+  }
+
+  /* Code blocks */
+  pre {
+    background: #f4f6f8;
+    border-radius: 12px;
+    padding: 14px 16px;
+    overflow-x: auto;
+    margin: 0 0 16px;
+
+    code {
+      background: none;
+      padding: 0;
+    }
+  }
+}
+
+/* ── Bottom bookmark CTA ─────────────────────────────────────── */
+
+.device-manual-cta {
+  padding: 8px 20px 24px;
+  background: white;
+  text-align: center;
+}
+
+.device-manual-cta-hint {
+  font-size: 13px;
+  color: #999;
+  margin: 0 0 10px;
+}
+
+.device-manual-cta-note {
+  font-size: 12px;
+  color: #bbb;
+  margin: 8px 0 0;
+  line-height: 1.5;
+}
+
+.device-manual-cta-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  width: 100%;
+  padding: 16px;
+  background: #4ECDC4;
+  color: white;
+  border: none;
+  border-radius: 50px;
+  font-size: 16px;
+  font-weight: 700;
+  font-family: "Space Grotesk", sans-serif;
+  cursor: pointer;
+  text-decoration: none;
+  transition: opacity 0.2s;
+
+  &:hover { opacity: 0.9; color: white; }
+  &:active { opacity: 0.8; }
+
+  i { font-size: 15px; }
+
+  /* Unsave state — outline style */
+  &--saved {
+    background: transparent;
+    border: 2px solid #4ECDC4;
+    color: #4ECDC4;
+    padding: 14px;
+
+    &:hover { background: rgba(78, 205, 196, 0.08); color: #4ECDC4; }
   }
 }

--- a/app/javascript/controllers/manual_controller.js
+++ b/app/javascript/controllers/manual_controller.js
@@ -1,0 +1,100 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  connect() {
+    this.#wrapSections()
+    this.#markStepHeadings()
+    this.#markStepLists()
+    this.#positionTimelines()
+    this.#observeCards()
+  }
+
+  disconnect() {
+    this.#observer?.disconnect()
+  }
+
+  // 1. Wrap each h2 + following siblings into a .manual-card div
+  #wrapSections() {
+    const children = Array.from(this.element.children)
+    let card = null
+    children.forEach(el => {
+      if (el.tagName === "H2") {
+        card = document.createElement("div")
+        card.className = "manual-card"
+        this.element.insertBefore(card, el)
+      }
+      if (card) card.appendChild(el)
+    })
+  }
+
+  // 2. Number direct-child elements that start with <strong> as step headings.
+  //    Add .has-timeline to the card only when steps are found.
+  #markStepHeadings() {
+    this.element.querySelectorAll(".manual-card").forEach(card => {
+      let step = 0
+      Array.from(card.children).forEach(child => {
+        if (child.tagName === "H2") return
+        const first = child.firstElementChild
+        if (first && first.tagName === "STRONG") {
+          step++
+          child.classList.add("manual-step-heading")
+          child.setAttribute("data-step", step)
+        }
+      })
+      if (step > 0) card.classList.add("has-timeline")
+    })
+  }
+
+  // 3. Mark ol lists whose first li starts with bold as step-title lists
+  #markStepLists() {
+    this.element.querySelectorAll(".manual-card ol").forEach(ol => {
+      const firstLi = ol.querySelector(":scope > li")
+      if (!firstLi) return
+      const firstEl = firstLi.firstElementChild
+      if (firstEl && (firstEl.tagName === "STRONG" ||
+          (firstEl.tagName === "P" && firstEl.firstElementChild && firstEl.firstElementChild.tagName === "STRONG"))) {
+        ol.classList.add("manual-step-list")
+        ol.closest(".manual-card").classList.add("has-timeline")
+        let s = 0
+        ol.querySelectorAll(":scope > li").forEach(li => {
+          s++
+          li.setAttribute("data-step", s)
+        })
+      }
+    })
+  }
+
+  // 4. Align the vertical line to start and end at the center of the first/last circles.
+  //    Uses CSS variables so the ::before pseudo-element can read them.
+  #positionTimelines() {
+    this.element.querySelectorAll(".manual-card.has-timeline").forEach(card => {
+      const circles = card.querySelectorAll(".manual-step-heading, ol.manual-step-list > li")
+      if (!circles.length) return
+      const first = circles[0]
+      const last = circles[circles.length - 1]
+      card.style.setProperty("--timeline-top", (first.offsetTop + 17) + "px")
+      const lastCircleCenter = last.offsetTop + 17
+      card.style.setProperty("--timeline-bottom", (card.offsetHeight - lastCircleCenter) + "px")
+    })
+  }
+
+  // 5. Fade-in each card as it scrolls into view, with a staggered delay.
+  #observeCards() {
+    const cards = this.element.querySelectorAll(".manual-card")
+
+    this.#observer = new IntersectionObserver((entries) => {
+      entries.forEach(entry => {
+        if (!entry.isIntersecting) return
+        entry.target.classList.add("is-visible")
+        this.#observer.unobserve(entry.target)
+      })
+    }, { threshold: 0.08 })
+
+    cards.forEach((card, i) => {
+      card.style.transitionDelay = `${i * 80}ms`
+      this.#observer.observe(card)
+    })
+  }
+
+  #observer = null
+}

--- a/app/views/devices/manual.html.erb
+++ b/app/views/devices/manual.html.erb
@@ -1,9 +1,9 @@
-<%# Text Manual page — device photo + full instructions %>
-<% content_for :title, "#{@device.name} Manual" %>
+<%# Text Manual page — redesigned with step-by-step layout %>
+<% content_for :title, "#{@device.name} — Text Manual" %>
 
-<div class="device-page">
+<div class="device-page device-page--manual">
 
-  <%# Header: back + title + save/unsave bookmark icon %>
+  <%# Header: back + TEXT MANUAL label + device name + bookmark icon %>
   <div class="device-header">
     <%= link_to device_path(@device), class: "device-back-link" do %>
       <i class="fa-solid fa-arrow-left"></i>
@@ -12,63 +12,67 @@
       <span class="device-identified-label">TEXT MANUAL</span>
       <h1 class="device-title"><%= @device.name %></h1>
     </div>
-    <%# Save / Unsave bookmark (top-right): if saved, show filled icon + unsave; else outline + save (or redirect to sign up) %>
     <div class="device-header-bookmark">
       <% if @bookmark %>
-        <%= button_to bookmark_path(@bookmark), method: :delete, class: "device-bookmark-btn device-bookmark-btn--saved", title: "Unsave", form: { data: { turbo_confirm: "Remove from saved manuals?" } } do %>
+        <%= button_to bookmark_path(@bookmark), method: :delete,
+              class: "device-bookmark-btn device-bookmark-btn--saved",
+              title: "Unsave",
+              form: { data: { turbo_confirm: "Remove from saved manuals?" } } do %>
           <i class="fa-solid fa-bookmark"></i>
         <% end %>
       <% else %>
-        <%= button_to bookmarks_path(device_id: @device.id), method: :post, class: "device-bookmark-btn device-bookmark-btn--unsaved", title: "Save" do %>
+        <%= button_to bookmarks_path(device_id: @device.id), method: :post,
+              class: "device-bookmark-btn",
+              title: "Save" do %>
           <i class="fa-regular fa-bookmark"></i>
         <% end %>
       <% end %>
     </div>
   </div>
 
-  <%# Device photo %>
-  <div class="device-hero">
-    <%= device_image_tag(@device, class: "device-hero-img", alt: @device.name) %>
+  <%# Hero image — full-width, edge-to-edge %>
+  <div class="device-manual-hero">
+    <%= device_image_tag(@device, class: "device-manual-hero-img", alt: @device.name) %>
+    <div class="device-manual-hero-overlay"></div>
   </div>
 
-  <%# Bookmark section: sign-in prompt when logged out, save button when logged in and not saved, saved state when saved %>
-  <div class="device-manual-bookmark-section">
+  <%# Intro: teal label + large device name + subtitle %>
+  <div class="device-manual-intro">
+    <span class="device-manual-intro-label">Text Manual</span>
+    <h2 class="device-manual-intro-title"><%= @device.name %></h2>
+    <p class="device-manual-intro-subtitle">Follow these steps to get started with your device.</p>
+  </div>
+
+  <%# Full markdown instructions — Stimulus controller handles card wrapping + timeline %>
+  <div class="device-manual-body" data-controller="manual">
+    <%= markdown(@device.text_instructions) %>
+  </div>
+
+  <%# Bookmark section — pinned to bottom %>
+  <div class="device-manual-cta">
     <% if !user_signed_in? %>
-      <p class="device-manual-signin-hint text-muted">Sign in to bookmark this device.</p>
-      <%= button_to bookmarks_path(device_id: @device.id), method: :post, class: "btn device-btn-manual" do %>
-        <div class="device-btn-icon">
-          <i class="fa-regular fa-bookmark"></i>
-        </div>
-        <div class="device-btn-label">
-          <span>Bookmark Device</span>
-        </div>
+      <p class="device-manual-cta-hint">Sign in to bookmark this device</p>
+      <%= button_to bookmarks_path(device_id: @device.id), method: :post,
+            class: "device-manual-cta-btn" do %>
+        <i class="fa-regular fa-bookmark"></i>
+        Bookmark Device
       <% end %>
-      <p class="small text-muted mt-1">You’ll be taken to sign up or sign in; the manual will be saved after you register or log in.</p>
+      <p class="device-manual-cta-note">You'll be redirected to sign in; the manual will be saved after.</p>
     <% elsif @bookmark %>
-      <p class="device-manual-saved-hint text-muted">This device is in your Saved Manuals.</p>
-      <%= button_to bookmark_path(@bookmark), method: :delete, class: "btn device-btn-manual device-btn-manual--outline", form: { data: { turbo_confirm: "Remove from saved manuals?" } } do %>
-        <div class="device-btn-icon">
-          <i class="fa-solid fa-bookmark"></i>
-        </div>
-        <div class="device-btn-label">
-          <span>Unsave</span>
-        </div>
+      <p class="device-manual-cta-hint">This device is in your Saved Manuals.</p>
+      <%= button_to bookmark_path(@bookmark), method: :delete,
+            class: "device-manual-cta-btn device-manual-cta-btn--saved",
+            form: { data: { turbo_confirm: "Remove from saved manuals?" } } do %>
+        <i class="fa-solid fa-bookmark"></i>
+        Unsave Device
       <% end %>
     <% else %>
-      <%= button_to bookmarks_path(device_id: @device.id), method: :post, class: "btn device-btn-manual" do %>
-        <div class="device-btn-icon">
-          <i class="fa-regular fa-bookmark"></i>
-        </div>
-        <div class="device-btn-label">
-          <span>Bookmark Device</span>
-        </div>
+      <%= button_to bookmarks_path(device_id: @device.id), method: :post,
+            class: "device-manual-cta-btn" do %>
+        <i class="fa-regular fa-bookmark"></i>
+        Bookmark Device
       <% end %>
     <% end %>
-  </div>
-
-  <%# Full text instructions %>
-  <div class="device-manual">
-    <%= markdown(@device.text_instructions) %>
   </div>
 
 </div>


### PR DESCRIPTION

1. Redesigned the text manual page with a card-based layout — each markdown `h2` section is wrapped into a white card with rounded corners and a subtle shadow
2. Added numbered teal circles and a vertical connector line that runs precisely between the first and last step circle in each card
3. All JavaScript extracted from the view into a dedicated Stimulus controller (`manual_controller.js`) keeping the view clean
Added scroll-triggered fade-in animation on cards using `IntersectionObserver` with staggered delays for a sleek entrance effect


