### PR TITLE
Fix Cloudinary uploads by passing tempfile path instead of StringIO

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -50,7 +50,7 @@ class Device < ApplicationRecord
   end
 
   def self.upload_image_to_cloudinary(uploaded_image)
-    source = uploaded_image.is_a?(String) ? uploaded_image : StringIO.new(uploaded_image.read)
+    source = uploaded_image.is_a?(String) ? uploaded_image : uploaded_image.tempfile.path
     result = ::Cloudinary::Uploader.upload(source, folder: "know-how-now/devices", resource_type: "image")
     result["secure_url"]
   rescue StandardError => e

--- a/app/models/video.rb
+++ b/app/models/video.rb
@@ -10,7 +10,7 @@ class Video < ApplicationRecord
   validates :device_id, uniqueness: { message: "already has a video" }
 
   def self.upload_video_to_cloudinary(uploaded_video)
-    source = uploaded_video.is_a?(String) ? uploaded_video : StringIO.new(uploaded_video.read)
+    source = uploaded_video.is_a?(String) ? uploaded_video : uploaded_video.tempfile.path
     result = ::Cloudinary::Uploader.upload(source, folder: "know-how-now/videos", resource_type: "video")
     result["secure_url"]
   rescue StandardError => e


### PR DESCRIPTION
Reading large files into memory with StringIO was causing silent upload failures on Heroku's memory-constrained dynos. Passing the tempfile path directly is more efficient and reliable for both image and video uploads.